### PR TITLE
Fix undefined buy book market entries as null on ivm

### DIFF
--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -734,7 +734,7 @@ class SmartContracts {
         };
         let getApiProp = (k) => {
           const v = _sscglobal_api.getSync(k, { copy: true });
-          return typeof v !== 'undefined' ? v : null;
+          return typeof v !== 'undefined' ? v : undefined;
         };
         let getDbProp = (k) => {
           const v = _sscglobal_db.getSync(k, { copy: true });


### PR DESCRIPTION
HE Blocks 1351741, 13552906 and 1354493 had market contract events for the orderClosed that were processing orders with txId = null (when it was expected for these specific orders not to have a txId field), causing a divergence from what old VM2 would process.

By interpreting the API calls the right way, treating undefined as undefined instead of converting them to null, it avoids showing the "txId = null" field on the IVM code (for these specific orders). This fixes the issue of those 3 (actually 4, as there is another sell one too) orders not showing the "txId" field on those initial transactions.

Troubleshoot done with @eonwarped