### PR TITLE
Fix when mainBlock is null when not comparing with hashVerificationNode

### DIFF
--- a/plugins/Blockchain.js
+++ b/plugins/Blockchain.js
@@ -145,7 +145,7 @@ async function producePendingTransactions(
             }
 
             await addBlock(newBlock);
-          } else if (mainBlock.refHiveBlockNumber === newBlock.refHiveBlockNumber) {
+          } else if (mainBlock?.refHiveBlockNumber === newBlock.refHiveBlockNumber) {
             throw new Error(`Block mismatch with api \nMain: ${JSON.stringify(mainBlock, null, 2)}, \nThis: ${JSON.stringify(newBlock, null, 2)}`);
           }
         } catch (e) {


### PR DESCRIPTION
This was mentioned by @ShmoogleOsukami at:
https://github.com/hive-engine/hivesmartcontracts/issues/107